### PR TITLE
missing translations for locale in source

### DIFF
--- a/lib/fractual_i18n/phrases.rb
+++ b/lib/fractual_i18n/phrases.rb
@@ -18,7 +18,9 @@ class FractualI18n::Phrases
       keys << last_key
       keys.map! { |key| key.delete_prefix("_") } # remove underscore from partial name
 
-      content[locale.to_s] = content.fetch(locale.to_s, {}).merge(translations.dig(locale.to_s, *keys))
+      if new_content = translations.dig(locale.to_s, *keys)
+        content[locale.to_s] = content.fetch(locale.to_s, {}).merge(new_content)
+      end
 
       File.write(filename, content.to_yaml(line_width: 200))
     end

--- a/lib/fractual_i18n/version.rb
+++ b/lib/fractual_i18n/version.rb
@@ -1,3 +1,3 @@
 module FractualI18n
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Error was raised in case there were 2 locales specified but source file contained only one:

locales => de, en
source file:

```
en:
   something: aonther
 ``` 
  